### PR TITLE
feat: implement CDC compaction snapshot support

### DIFF
--- a/.github/workflows/compact-cdc.yml
+++ b/.github/workflows/compact-cdc.yml
@@ -11,12 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Wrangler
-        run: npm install -g wrangler
-
       - name: Run Compaction Script
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          wrangler d1 execute shopping_list_db --remote --file=./sql/compact_cdc.sql
+          npx wrangler@4.45.0 d1 execute shopping_list_db --remote --file=./sql/compact_cdc.sql

--- a/.github/workflows/compact-cdc.yml
+++ b/.github/workflows/compact-cdc.yml
@@ -1,0 +1,22 @@
+name: Compact CDC Table
+
+on:
+  workflow_dispatch: # Allow manual triggering
+  schedule:
+    - cron: '0 0 * * 0' # Run every Sunday at midnight
+
+jobs:
+  compact:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Wrangler
+        run: npm install -g wrangler
+
+      - name: Run Compaction Script
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          wrangler d1 execute shopping_list_db --remote --file=./sql/compact_cdc.sql

--- a/sql/compact_cdc.sql
+++ b/sql/compact_cdc.sql
@@ -2,7 +2,11 @@
 -- This script reduces the size of the CDC log by keeping only the latest state for each item
 -- and inserting a 'compact' record to signal clients to reset their local storage.
 
+-- Wrap in a transaction to ensure atomicity
+BEGIN TRANSACTION;
+
 -- 1. Create a temporary table to store the latest state of all non-deleted items
+-- We exclude 'compaction-signal' to prevent it from being re-inserted as a 'create' record.
 CREATE TEMP TABLE latest_states AS
 SELECT id, 'create' as change, name, completed, deleted_at, updated_at, timestamp
 FROM shopping_items_cdc
@@ -10,7 +14,9 @@ WHERE sequence_number IN (
     SELECT MAX(sequence_number)
     FROM shopping_items_cdc
     GROUP BY id
-) AND deleted_at IS NULL;
+) 
+AND deleted_at IS NULL
+AND id != 'compaction-signal';
 
 -- 2. Delete all existing records from the CDC table
 DELETE FROM shopping_items_cdc;
@@ -28,3 +34,5 @@ FROM latest_states;
 
 -- 5. Cleanup
 DROP TABLE latest_states;
+
+COMMIT;

--- a/sql/compact_cdc.sql
+++ b/sql/compact_cdc.sql
@@ -1,0 +1,30 @@
+-- Compaction Script for shopping_items_cdc
+-- This script reduces the size of the CDC log by keeping only the latest state for each item
+-- and inserting a 'compact' record to signal clients to reset their local storage.
+
+-- 1. Create a temporary table to store the latest state of all non-deleted items
+CREATE TEMP TABLE latest_states AS
+SELECT id, 'create' as change, name, completed, deleted_at, updated_at, timestamp
+FROM shopping_items_cdc
+WHERE sequence_number IN (
+    SELECT MAX(sequence_number)
+    FROM shopping_items_cdc
+    GROUP BY id
+) AND deleted_at IS NULL;
+
+-- 2. Delete all existing records from the CDC table
+DELETE FROM shopping_items_cdc;
+
+-- 3. Insert the 'compact' signal record
+-- This record tells clients: "Everything before this point is gone. Clear your local DB."
+INSERT INTO shopping_items_cdc (id, change, name, completed, updated_at)
+VALUES ('compaction-signal', 'compact', 'Compaction Signal', 0, datetime('now'));
+
+-- 4. Re-insert the latest states
+-- These will have sequence numbers higher than the 'compact' record
+INSERT INTO shopping_items_cdc (id, change, name, completed, deleted_at, updated_at, timestamp)
+SELECT id, change, name, completed, deleted_at, updated_at, timestamp
+FROM latest_states;
+
+-- 5. Cleanup
+DROP TABLE latest_states;

--- a/sql/migration.sql
+++ b/sql/migration.sql
@@ -8,7 +8,7 @@ DROP TABLE IF EXISTS login_attempts;
 CREATE TABLE shopping_items_cdc (
   sequence_number INTEGER PRIMARY KEY AUTOINCREMENT,
   id TEXT NOT NULL,
-  change TEXT NOT NULL CHECK (change IN ('create', 'update')),
+  change TEXT NOT NULL CHECK (change IN ('create', 'update', 'compact')),
   name TEXT NOT NULL,
   completed BOOLEAN NOT NULL DEFAULT 0,
   deleted_at TEXT,

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -15,6 +15,12 @@ export const applyBackendChanges = (items: ShoppingItem[], backendChanges: Shopp
   
   // Process each change from the backend
   return backendChanges.reduce((updatedItems, change) => {
+    // Handle compaction record: Clear local state
+    if (change.change === 'compact') {
+      console.log('Compaction record received. Clearing local state.');
+      return [];
+    }
+
     // For create operations or items that don't exist locally
     const existingItemIndex = updatedItems.findIndex(item => item.id === change.id);
     

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -21,7 +21,7 @@ export interface ShoppingItem {
 
 export interface ShoppingItemCDC extends ShoppingItem {
   sequence_number?: number;
-  change: 'create' | 'update';
+  change: 'create' | 'update' | 'compact';
 }
 
 export default {
@@ -129,7 +129,7 @@ async function insertChanges(request: Request, env: Env): Promise<Response> {
     const payload = await request.json() as {
       changes: Array<{
         id: string;
-        change: 'create' | 'update';
+        change: 'create' | 'update' | 'compact';
         name: string;
         completed: boolean;
         deleted_at: string | null;

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -59,3 +59,113 @@ describe('Conflict Resolution (Concurrency)', () => {
     expect(result[0].id).toBe('2');
   });
 });
+
+describe('Compaction', () => {
+  const existingItems: ShoppingItem[] = [
+    {
+      id: '1',
+      name: 'Milk',
+      completed: false,
+      deleted_at: null,
+      updated_at: '2026-05-01T10:00:00.000Z',
+    },
+    {
+      id: '2',
+      name: 'Bread',
+      completed: true,
+      deleted_at: null,
+      updated_at: '2026-05-01T09:00:00.000Z',
+    },
+  ];
+
+  it('should clear local state when compact change is received', () => {
+    const compactChange: ShoppingItemCDC = {
+      id: 'compact',
+      name: '',
+      completed: false,
+      deleted_at: null,
+      change: 'compact',
+      updated_at: '2026-05-01T12:00:00.000Z',
+    };
+
+    const result = applyBackendChanges(existingItems, [compactChange]);
+    expect(result).toHaveLength(0);
+  });
+
+  it('should rebuild local state deterministically after compact followed by creates', () => {
+    const changes: ShoppingItemCDC[] = [
+      {
+        id: 'compact',
+        name: '',
+        completed: false,
+        deleted_at: null,
+        change: 'compact',
+        updated_at: '2026-05-01T12:00:00.000Z',
+      },
+      {
+        id: '1',
+        name: 'Milk',
+        completed: false,
+        deleted_at: null,
+        change: 'create',
+        updated_at: '2026-05-01T12:00:01.000Z',
+      },
+      {
+        id: '2',
+        name: 'Eggs',
+        completed: false,
+        deleted_at: null,
+        change: 'create',
+        updated_at: '2026-05-01T12:00:02.000Z',
+      },
+      {
+        id: '3',
+        name: 'Butter',
+        completed: true,
+        deleted_at: null,
+        change: 'create',
+        updated_at: '2026-05-01T12:00:03.000Z',
+      },
+    ];
+
+    const result = applyBackendChanges(existingItems, changes);
+
+    expect(result).toHaveLength(3);
+    expect(result.map(item => item.id)).toEqual(['1', '2', '3']);
+    expect(result.map(item => item.name)).toEqual(['Milk', 'Eggs', 'Butter']);
+    expect(result.find(item => item.id === '3')?.completed).toBe(true);
+  });
+
+  it('should not add deleted items after compact', () => {
+    const changes: ShoppingItemCDC[] = [
+      {
+        id: 'compact',
+        name: '',
+        completed: false,
+        deleted_at: null,
+        change: 'compact',
+        updated_at: '2026-05-01T12:00:00.000Z',
+      },
+      {
+        id: '1',
+        name: 'Milk',
+        completed: false,
+        deleted_at: '2026-05-01T11:00:00.000Z',
+        change: 'create',
+        updated_at: '2026-05-01T12:00:01.000Z',
+      },
+      {
+        id: '2',
+        name: 'Bread',
+        completed: false,
+        deleted_at: null,
+        change: 'create',
+        updated_at: '2026-05-01T12:00:02.000Z',
+      },
+    ];
+
+    const result = applyBackendChanges(existingItems, changes);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('2');
+  });
+});


### PR DESCRIPTION
## Summary
This PR implements the foundational support for CDC table compaction as discussed in issue #3. Instead of maintaining a separate snapshot table, we introduce a mechanism to "compact" the `shopping_items_cdc` log into a consistent snapshot while preserving sync integrity.

### Changes
- **Database Schema**: Updated `migration.sql` to include a new `compact` change type in the `shopping_items_cdc` table constraint.
- **Client Sync**: Modified `applyBackendChanges` in `src/lib/sync.ts` to handle the `compact` record. When received, the client clears its local state, allowing it to re-ingest the authoritative state from the subsequent compacted records.

### Context
This approach allows us to improve query performance by periodically pruning the CDC log via a GitHub Action (to be implemented), while ensuring that clients always stay in sync even if they miss individual deletion events.